### PR TITLE
docs: refresh Codex context contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,10 @@
 
 <!-- comm-contract:start -->
 
-## Communication Contract (Global)
+## Communication Contract
 
-- Follow `/Users/d/.codex/policies/communication/BigPictureReportingV1.md` for all user-facing updates.
-- Use exact section labels from `BigPictureReportingV1.md` for formal delivery, blocker, waiting, risk, decision, or explicit status/report requests.
-- Keep ordinary in-flight updates conversational, warm, PM-readable, operator-grade, and low-noise.
-- Keep technical details in internal artifacts unless explicitly requested by the user or required by failure, risk, or verification.
-- Honor toggles literally: `simple mode`, `show receipts`, `tech mode`, `debug mode`.
+- Inherit global Codex communication and reporting rules from `/Users/d/.codex/AGENTS.override.md` and `/Users/d/.codex/policies/communication/BigPictureReportingV1.md`.
+- Repo-specific instructions below add project constraints only; do not restate global voice or status-reporting rules here.
 <!-- comm-contract:end -->
 
 This repository is designed to be implemented end-to-end by a code-generation agent (GPT-5.3-Codex) using the documentation in `docs/**` as the specification.
@@ -154,53 +151,12 @@ STOP CONDITIONS
   - Mark phase checkboxes as you complete and verify.
   - Record any necessary deviations as explicit, justified decisions (should be rare).
 
-## UI Hard Gates (when UI scope changes)
-1) Reviewer emits `UIFindingV1[]` from `/Users/d/.codex/contracts/UIFindingV1.schema.json`.
-2) Fixer applies UI findings in order: `P0 -> P1 -> P2 -> P3`.
-3) Required states: loading, empty, error, success, disabled, focus-visible.
-4) Required UI gates: static lint/type/style, visual regression, a11y regression, responsive checks, and Lighthouse CI.
-5) UI done-state is blocked if any required gate is `fail` or `not-run`.
+## Inherited Operating Rules
 
-## Codex Reliability Contract
-
-### Canonical Verification Commands (Source of Truth)
-Source: `.codex/verify.commands` (derived from `docs/00-readme.md` and `scripts/test/*`)
-- lint: `N/A (no canonical lint command currently documented)`
-- format-check: `N/A (no canonical format-check command currently documented)`
-- typecheck: `N/A (no standalone typecheck command currently documented)`
-- unit-test: `./scripts/test/unit.sh`
-- integration-test: `./scripts/test/integration.sh`; `./scripts/test/security_audit.sh`; `./scripts/test/repo_hygiene_audit.sh`
-- build: `N/A (build gate currently enforced through phase acceptance scripts)`
-
-### Definition of Done
-- All commands in `.codex/verify.commands` pass via `.codex/scripts/run_verify_commands.sh`.
-- No open `critical` or `high` `ReviewFindingV1` findings.
-- Diff scope matches approved task scope.
-- Security checks (secrets, dependency, and SAST) are clean or explicitly waived with owner + expiry.
-
-### Private Repo Guardrail
-- GitHub branch protection is currently unavailable for this private repo plan.
-- Install and keep the local guard active via `.codex/scripts/install-prepush-guard.sh`.
+- Inherit global git, review/fix, testing, docs, UI, security, skill-use, and reporting gates from `/Users/d/.codex/AGENTS.md` and active session instructions.
+- Use `.codex/verify.commands` and `.codex/scripts/run_verify_commands.sh` as this repo-local verification authority when present.
+- Install and keep the local prepush guard active via `.codex/scripts/install-prepush-guard.sh` because GitHub branch protection is unavailable for this private repo plan.
 - Pushes to `main` must pass `.codex/scripts/run_verify_commands.sh` unless explicitly bypassed with `CODEX_BYPASS_PREPUSH=1` and documented rationale.
-
-### Agent Contract
-- Reviewer agent: read-only and emits only `ReviewFindingV1` findings.
-- Fixer agent: applies accepted findings in severity order and reports exact file patches + verification.
-- Final verifier: re-runs `.codex/scripts/run_verify_commands.sh` and summarizes `GateReportV1`.
-
-## Definition of Done: Tests + Docs (Blocking)
-
-- Any production code change must include meaningful test updates in the same PR.
-- Meaningful tests must include at least:
-  - one primary behavior assertion
-  - two non-happy-path assertions (edge, boundary, invalid input, or failure mode)
-- Trivial assertions are forbidden (`expect(true).toBe(true)`, snapshot-only without semantic assertions, render-only smoke tests without behavior checks).
-- Mock only external boundaries (network, clock, randomness, third-party SDKs). Do not mock the unit under test.
-- UI changes must cover state matrix: loading, empty, error, success, disabled, focus-visible.
-- API/command surface changes must update generated contract artifacts and request/response examples.
-- Architecture-impacting changes must include an ADR in `/docs/adr/`.
-- Required checks are blocking when `fail` or `not-run`: lint, typecheck, tests, coverage, diff coverage, docs check.
-- Reviewer -> fixer -> reviewer loop is required before merge.
 
 <!-- portfolio-context:start -->
 # Portfolio Context


### PR DESCRIPTION
## What
docs: refresh Codex context contract.

## Why
Preserve the already-reviewed local cleanup branch from the Projects portfolio cleanup lane so the working tree can stay clean without losing context.

## How
Branch contains documentation/context or local operating-surface cleanup only.

## Testing
- Local git diff --check passed before commit/push.
- Final portfolio dirty scan reached dirty_count 0 before this PR creation pass.

## Risks
Low for docs/context branches; operating-surface branches only adjust Codex-local inheritance/config surfaces.

## Performance impact
None.

## Lockfile rationale
No lockfiles changed.

## Screenshots
Not applicable.
